### PR TITLE
next-privious course button and css changes

### DIFF
--- a/src/app/client/src/app/modules/learn/components/course-consumption/assessment-player/assessment-player.component.html
+++ b/src/app/client/src/app/modules/learn/components/course-consumption/assessment-player/assessment-player.component.html
@@ -76,13 +76,13 @@
       <!-- Previous module button -->
       <button class="sb-btn sb-btn-link sb-btn-link-primary sb-btn-normal sb-left-icon-btn" aria-label="previous-module" *ngIf="prevModule"
         tabindex="0" (click)="navigateToPlayerPage(prevModule); logTelemetry('previous-module', prevModule, true);">
-        <i class="icon-svg icon-svg--xxs icon-back mr-4 rotate-90" role="img" aria-label="arrow-up"><svg class="icon icon-svg--primary"><use xlink:href="assets/images/sprite.svg#arrow-up"></use></svg></i>{{generaliseLabelService?.frmelmnts?.lbl?.prevModule | translate}}
+        <i class="icon-svg icon-svg--xxs icon-back mr-4 rotate-90" role="img" aria-label="arrow-up"><svg class="icon icon-svg--primary"><use xlink:href="assets/images/sprite.svg#arrow-up"></use></svg></i>{{generaliseLabelService?.frmelmnts?.lbl?.prevModule || 'Prev. module' | translate}}
       </button>
       <!-- Previous Module button -->
       <!-- Next Module button -->
       <button class="sb-btn sb-btn-link sb-btn-link-primary sb-btn-normal sb-right-icon-btn ml-auto" aria-label="next-module" *ngIf="nextModule"
         tabindex="0" (click)="navigateToPlayerPage(nextModule); logTelemetry('next-module', nextModule, true)">
-        {{generaliseLabelService?.frmelmnts?.lbl?.nextModule | translate}}<i class="icon-svg icon-svg--xxs icon-back ml-4 rotate90" role="img" aria-label="arrow-up"><svg class="icon icon-svg--primary"><use xlink:href="assets/images/sprite.svg#arrow-up"></use></svg></i>
+        {{generaliseLabelService?.frmelmnts?.lbl?.nextModule || 'Next module' | translate}}<i class="icon-svg icon-svg--xxs icon-back ml-4 rotate90" role="img" aria-label="arrow-up"><svg class="icon icon-svg--primary"><use xlink:href="assets/images/sprite.svg#arrow-up"></use></svg></i>
       </button>
       <!-- Next Module button -->
     </div>

--- a/src/app/client/src/assets/styles/vendors/_slick.scss
+++ b/src/app/client/src/assets/styles/vendors/_slick.scss
@@ -259,18 +259,18 @@ $slick-opacity-not-active: 0 !default;
 
 @include respond-above(sm) {
   .slick-prev {
-    left: calculateRem(-24px);
+    left: calculateRem(-3px);
 
     [dir="rtl"] & {
-      right: calculateRem(-24px);
+      right: calculateRem(-3px);
     }
   }
 
   .slick-next {
-    right: calculateRem(-24px);
+    right: calculateRem(-3px);
 
     [dir="rtl"] & {
-      left: calculateRem(-24px);
+      left: calculateRem(-3px);
     }
   }
 }


### PR DESCRIPTION
# SunbirdEd - Portal
---

### 
1. 117452 - Added default button text (Previous/Next module) if text not loaded from language. 
2. 117795 - Css fix for Next and Previous Button while listing courses.
---

### Please choose applicable option 
#### Example
- [x] Applicable
- [ ] Not applicable

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
