### PR TITLE
135032 - retain selected filter in all tab and fixed placeholder shif…

### DIFF
--- a/src/app/client/package.json
+++ b/src/app/client/package.json
@@ -54,7 +54,7 @@
     "@angular/router": "^11.2.14",
     "@dicdikshaorg/chatbot-client": "3.0.3",
     "@dicdikshaorg/common-consumption": "4.12.11",
-    "@dicdikshaorg/common-form-elements": "5.1.14",
+    "@dicdikshaorg/common-form-elements": "5.1.17",
     "@dicdikshaorg/sb-content-section": "5.0.1",
     "@dicdikshaorg/sunbird-collection-editor": "4.5.0",
     "@dictrigyn/pdf-player": "^0.0.6",

--- a/src/app/client/src/assets/styles/styles.scss
+++ b/src/app/client/src/assets/styles/styles.scss
@@ -49,3 +49,16 @@
         }
     }
 }
+
+app-search-filter .sb-mat__dropdown.mat-form-field-appearance-fill.mat-form-field-should-float .mat-form-field-flex,sb-search-facet-filter .sb-mat__dropdown.mat-form-field-appearance-fill.mat-form-field-should-float .mat-form-field-flex{
+    align-items: center !important;
+}
+app-search-filter .sb-mat__dropdown.mat-form-field-appearance-fill .mat-select-arrow-wrapper,sb-search-facet-filter .sb-mat__dropdown.mat-form-field-appearance-fill .mat-select-arrow-wrapper {
+    transform: none !important;
+}
+app-search-filter .sb-mat__dropdown.mat-form-field-appearance-fill .mat-select-arrow,sb-search-facet-filter .sb-mat__dropdown.mat-form-field-appearance-fill .mat-select-arrow{
+    transform: none !important;
+}
+app-search-filter .sb-mat__dropdown.mat-form-field-appearance-fill.mat-form-field-should-float .mat-select, sb-search-facet-filter .sb-mat__dropdown.mat-form-field-appearance-fill.mat-form-field-should-float .mat-select{
+    margin-top: 0px !important;
+}


### PR DESCRIPTION
…ting issue using css

# SunbirdEd - Portal
---

###
1. UI Issues of the Filter dropdowns, when clicked on it, Placeholder text is shifting.

2. After selecting the filters in in all tab, and clicked on the card, and click on back button, the filter details are retained but its values     are not displayed in the facet filters dropdowns.
---

### Please choose applicable option 
#### Example
- [x] Applicable
- [ ] Not applicable

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
