### PR TITLE
151307- Remove condition that will draft content on opening content w…

### DIFF
--- a/src/app/client/src/app/modules/workspace/components/content-editors/collection-editor/collection-editor.component.ts
+++ b/src/app/client/src/app/modules/workspace/components/content-editors/collection-editor/collection-editor.component.ts
@@ -103,7 +103,7 @@ export class CollectionEditorComponent implements OnInit, OnDestroy {
     const lockInfo = _.pick(this.queryParams, 'lockKey', 'expiresAt', 'expiresIn');
     const allowedEditState = ['draft', 'allcontent', 'collaborating-on', 'uploaded', 'alltextbooks'].includes(this.routeParams.state);
     const allowedEditStatus = this.routeParams.contentStatus ? ['draft'].includes(this.routeParams.contentStatus.toLowerCase()) : false;
-    if (_.isEmpty(lockInfo) && allowedEditState && ( allowedEditStatus || this.userService.userProfile.rootOrgAdmin )) {
+    if (_.isEmpty(lockInfo) && allowedEditState && allowedEditStatus) {
       return combineLatest(
       this.tenantService.tenantData$,
       this.getCollectionDetails(),

--- a/src/app/client/src/app/modules/workspace/components/content-editors/new-collection-editor/new-collection-editor.component.ts
+++ b/src/app/client/src/app/modules/workspace/components/content-editors/new-collection-editor/new-collection-editor.component.ts
@@ -124,7 +124,7 @@ export class NewCollectionEditorComponent implements OnInit, OnDestroy {
     const lockInfo = _.pick(this.queryParams, 'lockKey', 'expiresAt', 'expiresIn');
     const allowedEditState = ['draft', 'allcontent', 'collaborating-on', 'uploaded', 'alltextbooks'].includes(this.routeParams.state);
     const allowedEditStatus = this.routeParams.contentStatus ? ['draft'].includes(this.routeParams.contentStatus.toLowerCase()) : false;
-    if (_.isEmpty(lockInfo) && allowedEditState && ( allowedEditStatus || this.userService.userProfile.rootOrgAdmin )) {
+    if (_.isEmpty(lockInfo) && allowedEditState && allowedEditStatus) { 
       return combineLatest(
         this.getCollectionDetails(),
         this.editorService.getOwnershipType(),


### PR DESCRIPTION
…ithout changing anything for ORG_ADMIN

# SunbirdEd - Portal
---

### **NCERT Courses tab should display the Live course with open batches**
There was code when an Org Admin opening any live content then it was creating a draft version for that live content. Removed condition for org admin and only creating draft when create draft button clicked
---

### Please choose applicable option 
#### Example
- [x] Applicable
- [ ] Not applicable

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
